### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A powerful, FastAPI-based gateway for the Model Context Protocol (MCP), designed to unify and scale your AI toolchain.
 
+<a href="https://glama.ai/mcp/servers/@ferrary7/MCPilot">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ferrary7/MCPilot/badge" alt="MCPilot MCP server" />
+</a>
+
 ## ✅ Current Status
 
 MCPilot is now **fully functional** with the following working features:


### PR DESCRIPTION
This PR adds a badge for the [MCPilot](https://glama.ai/mcp/servers/@ferrary7/MCPilot) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ferrary7/MCPilot">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ferrary7/MCPilot/badge" alt="MCPilot MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.